### PR TITLE
Revert "temporary fix to path while we're on a non public domain"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,7 @@ jobs:
       - run: yarn
       - run: yarn lint
       - run: yarn test
-      # - run: PATH_PREFIX=/ndx/ yarn build
-      - run: yarn build
+      - run: PATH_PREFIX=/ndx/ yarn build
 
       - name: Tar files
         run: tar -cf site.tar ./_site


### PR DESCRIPTION
can merge this when we're back on co-cddo.github.io/ndx