### PR TITLE
Fix catalogue badges displaying on separate lines

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -677,7 +677,7 @@ body.auth-choice-modal-open {
 // The remote-images plugin rewrites shield URLs to local paths and
 // markdown-it renders them as <img> inside a <p> with <br> between each,
 // so we target paragraphs that contain only images (no text content).
-.app-prose-scope p:has(> img[alt=""]):not(:has(:not(img, br))) {
+.app-prose-scope p:has(> img[alt=""]):not(:has(:not(img, br, a))) {
   display: flex;
   flex-wrap: wrap;
   gap: govuk-spacing(1);

--- a/src/catalogue/anthropic/claude.md
+++ b/src/catalogue/anthropic/claude.md
@@ -15,9 +15,7 @@ tags:
   - Large Language Model
 ---
 
-![](https://img.shields.io/badge/provider-anthropic-purple)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-anthropic-purple) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/aws/aws-empty-sandbox.md
+++ b/src/catalogue/aws/aws-empty-sandbox.md
@@ -17,10 +17,7 @@ try: true
 try_id: "9813d13d-af90-433d-888f-ec17ad17d714"
 ---
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
 
 ## About NDX
 

--- a/src/catalogue/aws/connect.md
+++ b/src/catalogue/aws/connect.md
@@ -15,9 +15,7 @@ tags:
   - Location Planning
 ---
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/aws/council-chatbot.md
+++ b/src/catalogue/aws/council-chatbot.md
@@ -24,12 +24,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 <!-- External URL dependency: https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/council-chatbot/ -->
 <!-- Maintained by: NDX Team | Last verified: 2025-12-05 -->
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-AI-orange)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/council-chatbot)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-AI-orange) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/council-chatbot)
 
 ## About NDX
 

--- a/src/catalogue/aws/foi-redaction.md
+++ b/src/catalogue/aws/foi-redaction.md
@@ -26,12 +26,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 <!-- External URL dependency: https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/foi-redaction/ -->
 <!-- Maintained by: NDX Team | Last verified: 2025-12-05 -->
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-AI-orange)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/foi-redaction)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-AI-orange) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/foi-redaction)
 
 ## About NDX
 

--- a/src/catalogue/aws/localgov-drupal.md
+++ b/src/catalogue/aws/localgov-drupal.md
@@ -33,13 +33,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-AI-orange)
-![](https://img.shields.io/badge/category-CMS-blue)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/localgov-drupal)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-AI-orange) ![](https://img.shields.io/badge/category-CMS-blue) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/localgov-drupal)
 
 ## Overview
 

--- a/src/catalogue/aws/minute.md
+++ b/src/catalogue/aws/minute.md
@@ -34,13 +34,7 @@ github_source: "https://github.com/i-dot-ai/minute"
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-AI-orange)
-![](https://img.shields.io/badge/category-Productivity-blue)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/i-dot-ai/minute)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-AI-orange) ![](https://img.shields.io/badge/category-Productivity-blue) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/i-dot-ai/minute)
 
 ## Overview
 

--- a/src/catalogue/aws/planning-ai.md
+++ b/src/catalogue/aws/planning-ai.md
@@ -26,12 +26,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 <!-- External URL dependency: https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/planning-ai/ -->
 <!-- Maintained by: NDX Team | Last verified: 2025-12-05 -->
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-AI-orange)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/planning-ai)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-AI-orange) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/planning-ai)
 
 ## About NDX
 

--- a/src/catalogue/aws/quicksight-dashboard.md
+++ b/src/catalogue/aws/quicksight-dashboard.md
@@ -23,12 +23,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 <!-- External URL dependency: https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/quicksight-dashboard/ -->
 <!-- Maintained by: NDX Team | Last verified: 2025-12-05 -->
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-Analytics-orange)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/quicksight-dashboard)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-Analytics-orange) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/quicksight-dashboard)
 
 ## About NDX
 

--- a/src/catalogue/aws/red-hat-openshift-on-aws.md
+++ b/src/catalogue/aws/red-hat-openshift-on-aws.md
@@ -19,8 +19,7 @@ tags:
   - cloud
 ---
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-private_sector-orange)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-private_sector-orange)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/aws/simply-readable.md
+++ b/src/catalogue/aws/simply-readable.md
@@ -33,13 +33,7 @@ github_source: "https://github.com/aws-samples/document-translation"
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-AI-orange)
-![](https://img.shields.io/badge/category-Accessibility-blue)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/aws-samples/document-translation)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-AI-orange) ![](https://img.shields.io/badge/category-Accessibility-blue) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/aws-samples/document-translation)
 
 ## Overview
 

--- a/src/catalogue/aws/smart-car-park.md
+++ b/src/catalogue/aws/smart-car-park.md
@@ -25,12 +25,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 <!-- External URL dependency: https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/smart-car-park/ -->
 <!-- Maintained by: NDX Team | Last verified: 2025-12-05 -->
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-IoT-orange)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/smart-car-park)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-IoT-orange) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/smart-car-park)
 
 ## About NDX
 

--- a/src/catalogue/aws/text-to-speech.md
+++ b/src/catalogue/aws/text-to-speech.md
@@ -24,12 +24,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 <!-- External URL dependency: https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/text-to-speech/ -->
 <!-- Maintained by: NDX Team | Last verified: 2025-12-05 -->
 
-![](https://img.shields.io/badge/provider-aws-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX:Try-purple)
-![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen)
-![](https://img.shields.io/badge/category-Accessibility-orange)
-[![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/text-to-speech)
+![](https://img.shields.io/badge/provider-aws-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX:Try-purple) ![](https://img.shields.io/badge/try_before_you_buy-available-brightgreen) ![](https://img.shields.io/badge/category-Accessibility-orange) [![View source on GitHub](https://img.shields.io/badge/source-GitHub-black?logo=github)](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/text-to-speech)
 
 ## About NDX
 

--- a/src/catalogue/cloudflare/zero-trust.md
+++ b/src/catalogue/cloudflare/zero-trust.md
@@ -15,9 +15,7 @@ tags:
   - Identity
 ---
 
-![](https://img.shields.io/badge/provider-cloudflare-orange)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-cloudflare-orange) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/figma/index.md
+++ b/src/catalogue/figma/index.md
@@ -17,10 +17,7 @@ tags:
   - security
 ---
 
-![](https://img.shields.io/badge/provider-figma-purple)
-![](https://img.shields.io/badge/compliance-ISO_27001-green)
-![](https://img.shields.io/badge/security-Cyber_Essentials_Plus-blue)
-![](https://img.shields.io/badge/access-SAML_SSO-orange)
+![](https://img.shields.io/badge/provider-figma-purple) ![](https://img.shields.io/badge/compliance-ISO_27001-green) ![](https://img.shields.io/badge/security-Cyber_Essentials_Plus-blue) ![](https://img.shields.io/badge/access-SAML_SSO-orange)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/gitlab/dedicated-for-government.md
+++ b/src/catalogue/gitlab/dedicated-for-government.md
@@ -22,8 +22,7 @@ tags:
 
 # GitLab Dedicated for Government
 
-![](https://img.shields.io/badge/provider-gitlab-green)
-![](https://img.shields.io/badge/owner-private_sector-orange)
+![](https://img.shields.io/badge/provider-gitlab-green) ![](https://img.shields.io/badge/owner-private_sector-orange)
 
 {{ govukButton({
   text: "Try GitLab",

--- a/src/catalogue/google/firebase.md
+++ b/src/catalogue/google/firebase.md
@@ -15,9 +15,7 @@ tags:
   - Mobile
 ---
 
-![](https://img.shields.io/badge/provider-google-blue)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-google-blue) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/govuk/forms.md
+++ b/src/catalogue/govuk/forms.md
@@ -17,11 +17,7 @@ tags:
   - beta
 ---
 
-![](https://img.shields.io/badge/provider-government-blue)
-![](https://img.shields.io/badge/owner-public_sector-green)
-![](https://img.shields.io/badge/access-government_approved-darkgreen)
-![](https://img.shields.io/badge/status-in_development-orange)
-![](https://img.shields.io/badge/procurement-not_required-brightgreen)
+![](https://img.shields.io/badge/provider-government-blue) ![](https://img.shields.io/badge/owner-public_sector-green) ![](https://img.shields.io/badge/access-government_approved-darkgreen) ![](https://img.shields.io/badge/status-in_development-orange) ![](https://img.shields.io/badge/procurement-not_required-brightgreen)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/govuk/notify.md
+++ b/src/catalogue/govuk/notify.md
@@ -17,10 +17,7 @@ tags:
   - low-cost
 ---
 
-![](https://img.shields.io/badge/provider-government-blue)
-![](https://img.shields.io/badge/owner-public_sector-green)
-![](https://img.shields.io/badge/access-government_approved-darkgreen)
-![](https://img.shields.io/badge/procurement-not_required-brightgreen)
+![](https://img.shields.io/badge/provider-government-blue) ![](https://img.shields.io/badge/owner-public_sector-green) ![](https://img.shields.io/badge/access-government_approved-darkgreen) ![](https://img.shields.io/badge/procurement-not_required-brightgreen)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/govuk/one-login.md
+++ b/src/catalogue/govuk/one-login.md
@@ -17,11 +17,7 @@ tags:
   - beta
 ---
 
-![](https://img.shields.io/badge/provider-government-blue)
-![](https://img.shields.io/badge/owner-public_sector-green)
-![](https://img.shields.io/badge/access-government_approved-darkgreen)
-![](https://img.shields.io/badge/status-beta-orange)
-![](https://img.shields.io/badge/procurement-not_required-brightgreen)
+![](https://img.shields.io/badge/provider-government-blue) ![](https://img.shields.io/badge/owner-public_sector-green) ![](https://img.shields.io/badge/access-government_approved-darkgreen) ![](https://img.shields.io/badge/status-beta-orange) ![](https://img.shields.io/badge/procurement-not_required-brightgreen)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/govuk/pay.md
+++ b/src/catalogue/govuk/pay.md
@@ -17,10 +17,7 @@ tags:
   - low-cost
 ---
 
-![](https://img.shields.io/badge/provider-government-blue)
-![](https://img.shields.io/badge/owner-public_sector-green)
-![](https://img.shields.io/badge/access-government_approved-darkgreen)
-![](https://img.shields.io/badge/procurement-not_required-brightgreen)
+![](https://img.shields.io/badge/provider-government-blue) ![](https://img.shields.io/badge/owner-public_sector-green) ![](https://img.shields.io/badge/access-government_approved-darkgreen) ![](https://img.shields.io/badge/procurement-not_required-brightgreen)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/great-wave-ai/great-wave-ai.md
+++ b/src/catalogue/great-wave-ai/great-wave-ai.md
@@ -17,8 +17,7 @@ tags:
   - Agent Orchestration
 ---
 
-![](https://img.shields.io/badge/provider-Great_Wave_AI-purple)
-![](https://img.shields.io/badge/owner-private_sector-orange)
+![](https://img.shields.io/badge/provider-Great_Wave_AI-purple) ![](https://img.shields.io/badge/owner-private_sector-orange)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/greenbridge/ai-parking-solution.md
+++ b/src/catalogue/greenbridge/ai-parking-solution.md
@@ -20,9 +20,7 @@ tags:
   - uk-government
 ---
 
-![](https://img.shields.io/badge/provider-greenbridge-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-greenbridge-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/ibm/cloud-for-government.md
+++ b/src/catalogue/ibm/cloud-for-government.md
@@ -15,9 +15,7 @@ tags:
   - AI
 ---
 
-![](https://img.shields.io/badge/provider-ibm-blue)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-ibm-blue) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/kong/index.md
+++ b/src/catalogue/kong/index.md
@@ -15,9 +15,7 @@ tags:
   - cloud
 ---
 
-![](https://img.shields.io/badge/provider-kong-blue)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-kong-blue) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/linkedin/learning-solutions.md
+++ b/src/catalogue/linkedin/learning-solutions.md
@@ -18,10 +18,7 @@ tags:
   - enterprise
 ---
 
-![](https://img.shields.io/badge/provider-linkedin-blue)
-![](https://img.shields.io/badge/owner-commercial-orange)
-![](https://img.shields.io/badge/access-direct_procurement-green)
-![](https://img.shields.io/badge/integration-microsoft_365-brightgreen)
+![](https://img.shields.io/badge/provider-linkedin-blue) ![](https://img.shields.io/badge/owner-commercial-orange) ![](https://img.shields.io/badge/access-direct_procurement-green) ![](https://img.shields.io/badge/integration-microsoft_365-brightgreen)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/metoffice/met-office-postcode-sector-weather-forecasts-free.md
+++ b/src/catalogue/metoffice/met-office-postcode-sector-weather-forecasts-free.md
@@ -17,11 +17,7 @@ tags:
 
 > ==⚠️ Proof of concept only this will be dynamically pulled from Snowflake Marketplace==
 
-![](https://img.shields.io/badge/access-immediate-green)
-![](https://img.shields.io/badge/owner-public_sector-blue)
-![](https://img.shields.io/badge/data_last_updated-30/09/2024_18:30-blue)
-![](https://img.shields.io/badge/metadata_last_updated-30/09/2024_17:30-blue)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/access-immediate-green) ![](https://img.shields.io/badge/owner-public_sector-blue) ![](https://img.shields.io/badge/data_last_updated-30/09/2024_18:30-blue) ![](https://img.shields.io/badge/metadata_last_updated-30/09/2024_17:30-blue) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/microsoft/azure-red-hat-openshift.md
+++ b/src/catalogue/microsoft/azure-red-hat-openshift.md
@@ -18,8 +18,7 @@ tags:
   - cloud
 ---
 
-![](https://img.shields.io/badge/provider-microsoft-blue)
-![](https://img.shields.io/badge/owner-private_sector-orange)
+![](https://img.shields.io/badge/provider-microsoft-blue) ![](https://img.shields.io/badge/owner-private_sector-orange)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/microsoft/power-bi-government.md
+++ b/src/catalogue/microsoft/power-bi-government.md
@@ -18,10 +18,7 @@ tags:
   - Microsoft
 ---
 
-![](https://img.shields.io/badge/provider-microsoft-blue)
-![](https://img.shields.io/badge/owner-commercial-orange)
-![](https://img.shields.io/badge/access-direct_procurement-green)
-![](https://img.shields.io/badge/government-proven_adoption-brightgreen)
+![](https://img.shields.io/badge/provider-microsoft-blue) ![](https://img.shields.io/badge/owner-commercial-orange) ![](https://img.shields.io/badge/access-direct_procurement-green) ![](https://img.shields.io/badge/government-proven_adoption-brightgreen)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/microsoft/powerapps.md
+++ b/src/catalogue/microsoft/powerapps.md
@@ -15,9 +15,7 @@ tags:
   - cloud
 ---
 
-![](https://img.shields.io/badge/provider-microsoft-blue)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-microsoft-blue) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/oracle/oci.md
+++ b/src/catalogue/oracle/oci.md
@@ -15,9 +15,7 @@ tags:
   - UK
 ---
 
-![](https://img.shields.io/badge/provider-oracle-blue)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-oracle-blue) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/catalogue/salesforce/government-cloud.md
+++ b/src/catalogue/salesforce/government-cloud.md
@@ -22,9 +22,7 @@ tags:
 
 # Salesforce Government Cloud
 
-![](https://img.shields.io/badge/provider-salesforce-blue)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-salesforce-blue) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {{ govukButton({
   text: "Try Salesforce",

--- a/src/catalogue/servicenow/itsm.md
+++ b/src/catalogue/servicenow/itsm.md
@@ -16,9 +16,7 @@ tags:
   - digital transformation
 ---
 
-![](https://img.shields.io/badge/provider-servicenow-green)
-![](https://img.shields.io/badge/owner-private_sector-orange)
-![](https://img.shields.io/badge/access-NDX_OIDC-green)
+![](https://img.shields.io/badge/provider-servicenow-green) ![](https://img.shields.io/badge/owner-private_sector-orange) ![](https://img.shields.io/badge/access-NDX_OIDC-green)
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 


### PR DESCRIPTION
## Summary
- Joined shields.io badge markdown onto single lines (with a space between each) across 33 catalogue pages so they render inline instead of stacked vertically
- Updated the CSS badge selector to also allow `<a>`-wrapped badges (e.g. the GitHub source link), so the flexbox fallback handles linked badges correctly

## Test plan
- [ ] Verify badges display inline on catalogue pages (e.g. council-chatbot, minute, firebase)
- [ ] Verify the GitHub source badge still renders correctly alongside other badges
- [ ] Check pages that already had inline badges (e.g. planx) are unaffected