### PR TITLE
fix: sort signup domain dropdown by domain name

### DIFF
--- a/src/signup/main.test.ts
+++ b/src/signup/main.test.ts
@@ -461,17 +461,17 @@ describe("signup/main", () => {
       expect(select.options).toHaveLength(3)
     })
 
-    it("should sort domains by organisation name", () => {
+    it("should sort domains by domain name", () => {
       const domains: DomainInfo[] = [
-        { domain: "zebra.gov.uk", orgName: "Zebra Council" },
-        { domain: "alpha.gov.uk", orgName: "Alpha Council" },
+        { domain: "rbwm.gov.uk", orgName: "Windsor and Maidenhead Council" },
+        { domain: "cne-siar.gov.uk", orgName: "Western Isles Council" },
       ]
 
       populateDomainDropdown(domains)
 
       const select = document.getElementById("email-domain") as HTMLSelectElement
-      expect(select.options[1].value).toBe("alpha.gov.uk")
-      expect(select.options[2].value).toBe("zebra.gov.uk")
+      expect(select.options[1].value).toBe("cne-siar.gov.uk")
+      expect(select.options[2].value).toBe("rbwm.gov.uk")
     })
 
     it("should format option text as domain - orgName", () => {

--- a/src/signup/main.ts
+++ b/src/signup/main.ts
@@ -85,8 +85,8 @@ function populateDomainDropdown(domains: DomainInfo[]): void {
     return
   }
 
-  // Sort by organisation name for easier finding
-  const sortedDomains = [...domains].sort((a, b) => a.orgName.localeCompare(b.orgName))
+  // Sort by domain name for easier finding
+  const sortedDomains = [...domains].sort((a, b) => a.domain.localeCompare(b.domain))
 
   // Add options - format: "domain.gov.uk - Organisation Name"
   for (const domain of sortedDomains) {


### PR DESCRIPTION
## Summary
- The signup form's domain dropdown was sorted by `orgName`, putting `cne-siar.gov.uk` (Western Isles) and `rbwm.gov.uk` (Windsor and Maidenhead) under W.
- Sort by the `domain` string shown in each option so users can scan to the expected letter — `cne-siar.gov.uk` now appears under C, `rbwm.gov.uk` under R.

## Test plan
- [ ] `yarn test src/signup/main.test.ts` passes
- [ ] On the signup page, verify the dropdown is ordered by domain