### PR TITLE
feat(11ty): open external links in new tabs; convert pages to standard markdown

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -152,6 +152,50 @@ export default function (eleventyConfig) {
       },
     },
   })
+  // Open external links in a new tab with a visually hidden "(opens in new tab)" suffix.
+  // Why: GOV.UK pattern requires target="_blank" plus accessible warning text on links that escape the site.
+  eleventyConfig.amendLibrary("md", (mdLib) => {
+    const isExternal = (href) => /^(https?:)?\/\//i.test(href)
+
+    const renderToken = (tokens, idx, options, env, self) => self.renderToken(tokens, idx, options)
+    const defaultLinkOpen = mdLib.renderer.rules.link_open || renderToken
+    const defaultLinkClose = mdLib.renderer.rules.link_close || renderToken
+
+    mdLib.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+      const token = tokens[idx]
+      const hrefIndex = token.attrIndex("href")
+      if (hrefIndex >= 0 && isExternal(token.attrs[hrefIndex][1])) {
+        if (token.attrIndex("target") < 0) token.attrPush(["target", "_blank"])
+        if (token.attrIndex("rel") < 0) token.attrPush(["rel", "noopener noreferrer"])
+        token.meta = { ...(token.meta || {}), external: true }
+      }
+      return defaultLinkOpen(tokens, idx, options, env, self)
+    }
+
+    mdLib.renderer.rules.link_close = function (tokens, idx, options, env, self) {
+      let openIdx = idx - 1
+      let depth = 1
+      while (openIdx >= 0 && depth > 0) {
+        if (tokens[openIdx].type === "link_close") depth++
+        else if (tokens[openIdx].type === "link_open") depth--
+        if (depth === 0) break
+        openIdx--
+      }
+      const openToken = openIdx >= 0 ? tokens[openIdx] : null
+      let prefix = ""
+      if (openToken && openToken.meta && openToken.meta.external) {
+        let inner = ""
+        for (let i = openIdx + 1; i < idx; i++) {
+          if (tokens[i].content) inner += tokens[i].content
+        }
+        if (!/opens in (a |a new |new )?(tab|window)/i.test(inner)) {
+          prefix = ' <span class="govuk-visually-hidden">(opens in new tab)</span>'
+        }
+      }
+      return prefix + defaultLinkClose(tokens, idx, options, env, self)
+    }
+  })
+
   eleventyConfig.addPlugin(mermaidTransformPlugin, {
     theme: "default",
   })

--- a/src/catalogue/aws/bops-planning.md
+++ b/src/catalogue/aws/bops-planning.md
@@ -42,7 +42,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 
 > **Learning Artifact**: This is a pre-deployed demonstration environment for learning and exploration, not a production-ready product.
 
-The <a href="https://opendigitalplanning.org/back-office-planning-system-bops" target="_blank" rel="noopener">Back Office Planning System (BOPS)</a> is the open-source planning case management system developed by the <a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning</a> programme. It's used by councils including Lambeth, Southwark, and Buckinghamshire to process real planning applications.
+The [Back Office Planning System (BOPS)](https://opendigitalplanning.org/back-office-planning-system-bops) is the open-source planning case management system developed by the [Open Digital Planning](https://opendigitalplanning.org/) programme. It's used by councils including Lambeth, Southwark, and Buckinghamshire to process real planning applications.
 
 This scenario deploys the complete BOPS system with realistic sample data, so you can experience the full planning application lifecycle as a case officer would use it.
 
@@ -60,25 +60,25 @@ This scenario deploys the complete BOPS system with realistic sample data, so yo
 
 ### Planning Features
 
-| Feature                                                                                                                                                      | What it does                                                   |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/bops-planning/step-1/" target="_blank" rel="noopener">**Officer dashboard**</a>      | Case management with workload view and statutory deadlines     |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/bops-planning/step-2/" target="_blank" rel="noopener">**Application management**</a> | Browse, filter, and search 35 realistic planning cases         |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/bops-planning/step-3/" target="_blank" rel="noopener">**Assessment workflow**</a>    | Validation, consultation, assessment, and determination stages |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/bops-planning/step-4/" target="_blank" rel="noopener">**Applicants portal**</a>      | Public-facing portal with OS Maps and consultation comments    |
+| Feature                                                                                                            | What it does                                                   |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| [**Officer dashboard**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/bops-planning/step-1/)      | Case management with workload view and statutory deadlines     |
+| [**Application management**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/bops-planning/step-2/) | Browse, filter, and search 35 realistic planning cases         |
+| [**Assessment workflow**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/bops-planning/step-3/)    | Validation, consultation, assessment, and determination stages |
+| [**Applicants portal**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/bops-planning/step-4/)      | Public-facing portal with OS Maps and consultation comments    |
 
 </div>
 <div class="govuk-grid-column-one-half">
 
 ### Infrastructure
 
-| Component    | AWS Service                                                                                                           |
-| ------------ | --------------------------------------------------------------------------------------------------------------------- |
-| **Compute**  | <a href="https://aws.amazon.com/fargate/" target="_blank" rel="noopener">AWS Fargate (ECS)</a>                        |
-| **Database** | <a href="https://aws.amazon.com/rds/aurora/" target="_blank" rel="noopener">Amazon Aurora PostgreSQL</a> with PostGIS |
-| **Caching**  | <a href="https://aws.amazon.com/elasticache/" target="_blank" rel="noopener">Amazon ElastiCache (Redis)</a>           |
-| **HTTPS**    | <a href="https://aws.amazon.com/cloudfront/" target="_blank" rel="noopener">Amazon CloudFront</a> (2 distributions)   |
-| **Mapping**  | <a href="https://osdatahub.os.uk/" target="_blank" rel="noopener">Ordnance Survey Vector Tiles</a>                    |
+| Component    | AWS Service                                                                 |
+| ------------ | --------------------------------------------------------------------------- |
+| **Compute**  | [AWS Fargate (ECS)](https://aws.amazon.com/fargate/)                        |
+| **Database** | [Amazon Aurora PostgreSQL](https://aws.amazon.com/rds/aurora/) with PostGIS |
+| **Caching**  | [Amazon ElastiCache (Redis)](https://aws.amazon.com/elasticache/)           |
+| **HTTPS**    | [Amazon CloudFront](https://aws.amazon.com/cloudfront/) (2 distributions)   |
+| **Mapping**  | [Ordnance Survey Vector Tiles](https://osdatahub.os.uk/)                    |
 
 </div>
 </div>
@@ -150,7 +150,7 @@ Once you select **"Try this now"** above, your session environment will begin de
 - Statutory planning process built in
 - GOV.UK Design System aligned
 - Accessibility standards compliant
-- Data standards from <a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning</a>
+- Data standards from [Open Digital Planning](https://opendigitalplanning.org/)
 
 </div>
 </div>
@@ -159,10 +159,10 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 ## About BOPS
 
-<a href="https://opendigitalplanning.org/back-office-planning-system-bops" target="_blank" rel="noopener">BOPS</a> is developed by the **<a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning (ODP)</a>** programme, a collaboration between DLUHC and local planning authorities to modernise England's planning system.
+[BOPS](https://opendigitalplanning.org/back-office-planning-system-bops) is developed by the **[Open Digital Planning (ODP)](https://opendigitalplanning.org/)** programme, a collaboration between DLUHC and local planning authorities to modernise England's planning system.
 
 {{ govukInsetText({
-  html: "<strong>Part of the ODP ecosystem</strong> &bull; <a href='https://opendigitalplanning.org/back-office-planning-system-bops' target='_blank' rel='noopener'>BOPS</a> (back office) &bull; <a href='https://opendigitalplanning.org/plan-x' target='_blank' rel='noopener'>PlanX</a> (submissions) &bull; <a href='https://opendigitalplanning.org/digital-planning-data-and-api' target='_blank' rel='noopener'>Data & API standards</a>"
+  html: "<strong>Part of the ODP ecosystem</strong> &bull; [BOPS](https://opendigitalplanning.org/back-office-planning-system-bops) (back office) &bull; [PlanX](https://opendigitalplanning.org/plan-x) (submissions) &bull; [Data & API standards](https://opendigitalplanning.org/digital-planning-data-and-api)"
 }) }}
 
 <div class="govuk-grid-row">
@@ -219,7 +219,7 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 This scenario is built with open source infrastructure as code using AWS CDK (Cloud Development Kit) with Docker. The BOPS application is the same codebase used in production by UK councils.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/bops-planning" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/bops-planning)
 
 ---
 
@@ -235,10 +235,10 @@ This scenario is built with open source infrastructure as code using AWS CDK (Cl
 
 ## Learn more about BOPS
 
-- <a href="https://opendigitalplanning.org/back-office-planning-system-bops" target="_blank" rel="noopener">Back Office Planning System (BOPS) on Open Digital Planning</a>
-- <a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning programme</a>
-- <a href="https://opendigitalplanning.org/plan-x" target="_blank" rel="noopener">PlanX submission portal</a>
-- <a href="https://github.com/unboxed/bops" target="_blank" rel="noopener">BOPS source code on GitHub</a>
+- [Back Office Planning System (BOPS) on Open Digital Planning](https://opendigitalplanning.org/back-office-planning-system-bops)
+- [Open Digital Planning programme](https://opendigitalplanning.org/)
+- [PlanX submission portal](https://opendigitalplanning.org/plan-x)
+- [BOPS source code on GitHub](https://github.com/unboxed/bops)
 
 ---
 

--- a/src/catalogue/aws/council-chatbot.md
+++ b/src/catalogue/aws/council-chatbot.md
@@ -53,7 +53,7 @@ This sandbox includes a working implementation using:
 
 Before requesting your sandbox, explore the scenario documentation to understand what's deployed and how to interact with it:
 
-<a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/council-chatbot/" target="_blank" rel="noopener">View Council Chatbot scenario details</a>
+[View Council Chatbot scenario details](https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/council-chatbot/)
 
 ## Getting started
 
@@ -96,7 +96,7 @@ This scenario lets you evaluate whether AI-powered chatbots could work for your 
 
 This scenario is built with open source infrastructure as code. You can view the CloudFormation template, understand how it works, and adapt it for your own needs.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/council-chatbot" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/council-chatbot)
 
 ### Build your own
 

--- a/src/catalogue/aws/digital-planning-register.md
+++ b/src/catalogue/aws/digital-planning-register.md
@@ -42,7 +42,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 
 > **Learning Artifact**: This is a pre-deployed demonstration environment for learning and exploration, not a production-ready product.
 
-The <a href="https://github.com/tpximpact/digital-planning-register" target="_blank" rel="noopener">Digital Planning Register</a> is the open-source public-facing application built by <a href="https://www.tpximpact.com/" target="_blank" rel="noopener">TPXimpact</a> as part of the <a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning</a> ecosystem. It gives residents a unified, accessible way to search and view planning applications across councils — connecting to <a href="https://opendigitalplanning.org/back-office-planning-system-bops" target="_blank" rel="noopener">BOPS</a> back-office systems via API.
+The [Digital Planning Register](https://github.com/tpximpact/digital-planning-register) is the open-source public-facing application built by [TPXimpact](https://www.tpximpact.com/) as part of the [Open Digital Planning](https://opendigitalplanning.org/) ecosystem. It gives residents a unified, accessible way to search and view planning applications across councils — connecting to [BOPS](https://opendigitalplanning.org/back-office-planning-system-bops) back-office systems via API.
 
 Currently used by 9 UK councils including Camden, Lambeth, and Southwark.
 
@@ -60,24 +60,24 @@ Currently used by 9 UK councils including Camden, Lambeth, and Southwark.
 
 ### Register Features
 
-| Feature                                                                                                                                                               | What it does                                                |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/digital-planning-register/step-2/" target="_blank" rel="noopener">**Council selection**</a>   | Browse and select from configured councils                  |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/digital-planning-register/step-3/" target="_blank" rel="noopener">**Application search**</a>  | Search by reference, address, or description with filters   |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/digital-planning-register/step-3/" target="_blank" rel="noopener">**Application details**</a> | Maps, progress timeline, documents, comments, and decisions |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/digital-planning-register/step-4/" target="_blank" rel="noopener">**AWS architecture**</a>    | Stateless ECS Fargate deployment with CloudFront HTTPS      |
+| Feature                                                                                                                     | What it does                                                |
+| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [**Council selection**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/digital-planning-register/step-2/)   | Browse and select from configured councils                  |
+| [**Application search**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/digital-planning-register/step-3/)  | Search by reference, address, or description with filters   |
+| [**Application details**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/digital-planning-register/step-3/) | Maps, progress timeline, documents, comments, and decisions |
+| [**AWS architecture**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/digital-planning-register/step-4/)    | Stateless ECS Fargate deployment with CloudFront HTTPS      |
 
 </div>
 <div class="govuk-grid-column-one-half">
 
 ### Infrastructure
 
-| Component         | AWS Service                                                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Compute**       | <a href="https://aws.amazon.com/fargate/" target="_blank" rel="noopener">AWS Fargate (ECS)</a>                      |
-| **Load Balancer** | <a href="https://aws.amazon.com/elasticloadbalancing/" target="_blank" rel="noopener">Application Load Balancer</a> |
-| **HTTPS**         | <a href="https://aws.amazon.com/cloudfront/" target="_blank" rel="noopener">Amazon CloudFront</a>                   |
-| **Logging**       | <a href="https://aws.amazon.com/cloudwatch/" target="_blank" rel="noopener">Amazon CloudWatch</a>                   |
+| Component         | AWS Service                                                               |
+| ----------------- | ------------------------------------------------------------------------- |
+| **Compute**       | [AWS Fargate (ECS)](https://aws.amazon.com/fargate/)                      |
+| **Load Balancer** | [Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/) |
+| **HTTPS**         | [Amazon CloudFront](https://aws.amazon.com/cloudfront/)                   |
+| **Logging**       | [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/)                   |
 
 </div>
 </div>
@@ -158,10 +158,10 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 ## About the Digital Planning Register
 
-The <a href="https://github.com/tpximpact/digital-planning-register" target="_blank" rel="noopener">Digital Planning Register</a> is built by **<a href="https://www.tpximpact.com/" target="_blank" rel="noopener">TPXimpact</a>** as part of the **<a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning (ODP)</a>** ecosystem. It's the public-facing counterpart to <a href="https://opendigitalplanning.org/back-office-planning-system-bops" target="_blank" rel="noopener">BOPS</a>.
+The [Digital Planning Register](https://github.com/tpximpact/digital-planning-register) is built by **[TPXimpact](https://www.tpximpact.com/)** as part of the **[Open Digital Planning (ODP)](https://opendigitalplanning.org/)** ecosystem. It's the public-facing counterpart to [BOPS](https://opendigitalplanning.org/back-office-planning-system-bops).
 
 {{ govukInsetText({
-  html: "<strong>Part of the ODP ecosystem</strong> &bull; <a href='https://opendigitalplanning.org/back-office-planning-system-bops' target='_blank' rel='noopener'>BOPS</a> (back office) &bull; <a href='https://github.com/tpximpact/digital-planning-register' target='_blank' rel='noopener'>Digital Planning Register</a> (public) &bull; <a href='https://opendigitalplanning.org/plan-x' target='_blank' rel='noopener'>PlanX</a> (submissions)"
+  html: "<strong>Part of the ODP ecosystem</strong> &bull; [BOPS](https://opendigitalplanning.org/back-office-planning-system-bops) (back office) &bull; [Digital Planning Register](https://github.com/tpximpact/digital-planning-register) (public) &bull; [PlanX](https://opendigitalplanning.org/plan-x) (submissions)"
 }) }}
 
 <div class="govuk-grid-row">
@@ -218,7 +218,7 @@ The <a href="https://github.com/tpximpact/digital-planning-register" target="_bl
 
 This scenario is built with open source infrastructure as code using AWS CDK (Cloud Development Kit). The Digital Planning Register application is the same Next.js codebase used in production by UK councils.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/digital-planning-register" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/digital-planning-register)
 
 ---
 
@@ -234,10 +234,10 @@ This scenario is built with open source infrastructure as code using AWS CDK (Cl
 
 ## Learn more
 
-- <a href="https://github.com/tpximpact/digital-planning-register" target="_blank" rel="noopener">Digital Planning Register on GitHub</a>
-- <a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning programme</a>
-- <a href="https://opendigitalplanning.org/back-office-planning-system-bops" target="_blank" rel="noopener">BOPS - Back Office Planning System</a>
-- <a href="https://www.tpximpact.com/" target="_blank" rel="noopener">TPXimpact</a>
+- [Digital Planning Register on GitHub](https://github.com/tpximpact/digital-planning-register)
+- [Open Digital Planning programme](https://opendigitalplanning.org/)
+- [BOPS - Back Office Planning System](https://opendigitalplanning.org/back-office-planning-system-bops)
+- [TPXimpact](https://www.tpximpact.com/)
 
 ---
 

--- a/src/catalogue/aws/foi-redaction.md
+++ b/src/catalogue/aws/foi-redaction.md
@@ -55,7 +55,7 @@ This sandbox includes a working implementation using:
 
 Before requesting your sandbox, explore the scenario documentation to understand what's deployed and how to interact with it:
 
-<a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/foi-redaction/" target="_blank" rel="noopener">View FOI Redaction scenario details</a>
+[View FOI Redaction scenario details](https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/foi-redaction/)
 
 ## Getting started
 
@@ -98,7 +98,7 @@ This scenario lets you evaluate whether AI-assisted redaction could work for you
 
 This scenario is built with open source infrastructure as code. You can view the CloudFormation template, understand how it works, and adapt it for your own needs.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/foi-redaction" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/foi-redaction)
 
 ### Build your own
 

--- a/src/catalogue/aws/localgov-drupal.md
+++ b/src/catalogue/aws/localgov-drupal.md
@@ -59,27 +59,27 @@ LocalGov Drupal with AI showcases how UK councils can transform their content ma
 
 ### AI Content Features
 
-| Feature                                                                                                                                                             | AWS Service                                                                                         |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-4/" target="_blank" rel="noopener">**Content editing**</a>             | <a href="https://aws.amazon.com/bedrock/" target="_blank" rel="noopener">Amazon Bedrock</a>         |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-5/" target="_blank" rel="noopener">**Plain English conversion**</a>    | <a href="https://aws.amazon.com/bedrock/" target="_blank" rel="noopener">Amazon Bedrock</a>         |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-6/" target="_blank" rel="noopener">**Alt-text generation**</a>         | <a href="https://aws.amazon.com/rekognition/" target="_blank" rel="noopener">Amazon Rekognition</a> |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-8/" target="_blank" rel="noopener">**Text-to-speech**</a>              | <a href="https://aws.amazon.com/polly/" target="_blank" rel="noopener">Amazon Polly</a>             |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-9/" target="_blank" rel="noopener">**Translation (75+ languages)**</a> | <a href="https://aws.amazon.com/translate/" target="_blank" rel="noopener">Amazon Translate</a>     |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-7/" target="_blank" rel="noopener">**PDF-to-web conversion**</a>       | <a href="https://aws.amazon.com/textract/" target="_blank" rel="noopener">Amazon Textract</a>       |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-3/" target="_blank" rel="noopener">**Council branding**</a>            | <a href="https://aws.amazon.com/bedrock/" target="_blank" rel="noopener">Amazon Bedrock</a>         |
+| Feature                                                                                                                   | AWS Service                                               |
+| ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [**Content editing**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-4/)             | [Amazon Bedrock](https://aws.amazon.com/bedrock/)         |
+| [**Plain English conversion**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-5/)    | [Amazon Bedrock](https://aws.amazon.com/bedrock/)         |
+| [**Alt-text generation**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-6/)         | [Amazon Rekognition](https://aws.amazon.com/rekognition/) |
+| [**Text-to-speech**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-8/)              | [Amazon Polly](https://aws.amazon.com/polly/)             |
+| [**Translation (75+ languages)**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-9/) | [Amazon Translate](https://aws.amazon.com/translate/)     |
+| [**PDF-to-web conversion**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-7/)       | [Amazon Textract](https://aws.amazon.com/textract/)       |
+| [**Council branding**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-drupal/step-3/)            | [Amazon Bedrock](https://aws.amazon.com/bedrock/)         |
 
 </div>
 <div class="govuk-grid-column-one-half">
 
 ### Infrastructure
 
-| Component    | AWS Service                                                                                   |
-| ------------ | --------------------------------------------------------------------------------------------- |
-| **Compute**  | <a href="https://aws.amazon.com/fargate/" target="_blank" rel="noopener">AWS Fargate</a>      |
-| **Database** | <a href="https://aws.amazon.com/rds/aurora/" target="_blank" rel="noopener">Amazon Aurora</a> |
-| **Storage**  | <a href="https://aws.amazon.com/efs/" target="_blank" rel="noopener">Amazon EFS</a>           |
-| **CMS**      | <a href="https://www.drupal.org/" target="_blank" rel="noopener">Drupal 10</a>                |
+| Component    | AWS Service                                         |
+| ------------ | --------------------------------------------------- |
+| **Compute**  | [AWS Fargate](https://aws.amazon.com/fargate/)      |
+| **Database** | [Amazon Aurora](https://aws.amazon.com/rds/aurora/) |
+| **Storage**  | [Amazon EFS](https://aws.amazon.com/efs/)           |
+| **CMS**      | [Drupal 10](https://www.drupal.org/)                |
 
 </div>
 </div>
@@ -115,9 +115,9 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 ### Accessibility at Scale
 
-- **Auto alt-text** for images using <a href="https://aws.amazon.com/rekognition/" target="_blank" rel="noopener">Amazon Rekognition</a>
-- **Text-to-speech** via <a href="https://aws.amazon.com/polly/" target="_blank" rel="noopener">Amazon Polly</a> for audio access
-- **PDF conversion** with <a href="https://aws.amazon.com/textract/" target="_blank" rel="noopener">Amazon Textract</a>
+- **Auto alt-text** for images using [Amazon Rekognition](https://aws.amazon.com/rekognition/)
+- **Text-to-speech** via [Amazon Polly](https://aws.amazon.com/polly/) for audio access
+- **PDF conversion** with [Amazon Textract](https://aws.amazon.com/textract/)
 - Helps meet WCAG 2.1 Level AA requirements
 
 </div>
@@ -125,7 +125,7 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 ### Multilingual communities
 
-- **75+ languages** via <a href="https://aws.amazon.com/translate/" target="_blank" rel="noopener">Amazon Translate</a>
+- **75+ languages** via [Amazon Translate](https://aws.amazon.com/translate/)
 - Instant translation without manual costs
 - Consistent service delivery regardless of language
 
@@ -137,7 +137,7 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 ### Content efficiency
 
-- **AI drafting** powered by <a href="https://aws.amazon.com/bedrock/" target="_blank" rel="noopener">Amazon Bedrock</a>
+- **AI drafting** powered by [Amazon Bedrock](https://aws.amazon.com/bedrock/)
 - **Plain English conversion** for accessible communications
 - Reduced time on content creation and review
 
@@ -237,7 +237,7 @@ Rapid improvements with limited budget:
 
 ## Governance
 
-Since January 2023, LocalGov Drupal has been governed by the **<a href="https://opendigital.coop/" target="_blank" rel="noopener">Open Digital Cooperative</a>** - a not-for-profit multistakeholder cooperative ensuring long-term sustainability and democratic governance by member councils and suppliers.
+Since January 2023, LocalGov Drupal has been governed by the **[Open Digital Cooperative](https://opendigital.coop/)** - a not-for-profit multistakeholder cooperative ensuring long-term sustainability and democratic governance by member councils and suppliers.
 
 The platform represents true collaboration: councils share development costs and benefit from each other's investments. When one council builds a feature, all 56+ councils benefit.
 
@@ -247,7 +247,7 @@ The platform represents true collaboration: councils share development costs and
 
 This scenario is built with open source infrastructure as code using AWS CDK (Cloud Development Kit) with Docker. You can view the CDK project, Drupal configuration, and Docker setup, and adapt them for your own needs.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/localgov-drupal" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/localgov-drupal)
 
 ---
 
@@ -263,6 +263,6 @@ This scenario is built with open source infrastructure as code using AWS CDK (Cl
 
 ## Learn More About LocalGov Drupal
 
-- <a href="https://localgovdrupal.org/" target="_blank" rel="noopener">LocalGov Drupal official website</a>
-- <a href="https://docs.localgovdrupal.org/" target="_blank" rel="noopener">LocalGov Drupal documentation</a>
-- <a href="https://localgovdrupal.org/community/our-councils" target="_blank" rel="noopener">Councils using LocalGov Drupal</a>
+- [LocalGov Drupal official website](https://localgovdrupal.org/)
+- [LocalGov Drupal documentation](https://docs.localgovdrupal.org/)
+- [Councils using LocalGov Drupal](https://localgovdrupal.org/community/our-councils)

--- a/src/catalogue/aws/localgov-ims.md
+++ b/src/catalogue/aws/localgov-ims.md
@@ -42,7 +42,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 
 > **Learning Artifact**: This is a pre-deployed demonstration environment for learning and exploration, not a production-ready product.
 
-<a href="https://github.com/LocalGovIMS/localgov-ims" target="_blank" rel="noopener">LocalGov IMS</a> is an open-source income management system built for UK local authorities. It handles council tax, business rates, parking fines, housing rents, and other payment types — with integrated GOV.UK Pay for citizen-facing payments.
+[LocalGov IMS](https://github.com/LocalGovIMS/localgov-ims) is an open-source income management system built for UK local authorities. It handles council tax, business rates, parking fines, housing rents, and other payment types — with integrated GOV.UK Pay for citizen-facing payments.
 
 This scenario deploys the complete IMS with realistic seeded data, so you can explore the admin portal, manage accounts and transactions, and see how GOV.UK Pay integrates with council payment workflows.
 
@@ -60,26 +60,26 @@ This scenario deploys the complete IMS with realistic seeded data, so you can ex
 
 ### IMS Features
 
-| Feature                                                                                                                                                      | What it does                                             |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-1/" target="_blank" rel="noopener">**Admin portal**</a>            | Dashboard with navigation to all system areas            |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-2/" target="_blank" rel="noopener">**Accounts & transactions**</a> | 40 account holders, 500 payments across 19 fund types    |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-3/" target="_blank" rel="noopener">**User management**</a>         | 6 users with different roles (officer, cashier, auditor) |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-4/" target="_blank" rel="noopener">**Fund configuration**</a>      | 19 fund types from Council Tax to Housing Rents          |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-5/" target="_blank" rel="noopener">**Payment portal**</a>          | Citizen-facing payments via GOV.UK Pay sandbox           |
+| Feature                                                                                                            | What it does                                             |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| [**Admin portal**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-1/)            | Dashboard with navigation to all system areas            |
+| [**Accounts & transactions**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-2/) | 40 account holders, 500 payments across 19 fund types    |
+| [**User management**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-3/)         | 6 users with different roles (officer, cashier, auditor) |
+| [**Fund configuration**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-4/)      | 19 fund types from Council Tax to Housing Rents          |
+| [**Payment portal**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/localgov-ims/step-5/)          | Citizen-facing payments via GOV.UK Pay sandbox           |
 
 </div>
 <div class="govuk-grid-column-one-half">
 
 ### Infrastructure
 
-| Component          | AWS Service                                                                                                         |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **Compute**        | <a href="https://aws.amazon.com/ec2/" target="_blank" rel="noopener">Amazon EC2</a> (Windows Server 2022, IIS)      |
-| **Database**       | <a href="https://aws.amazon.com/rds/sqlserver/" target="_blank" rel="noopener">Amazon RDS SQL Server Express</a>    |
-| **Load balancing** | <a href="https://aws.amazon.com/elasticloadbalancing/" target="_blank" rel="noopener">Application Load Balancer</a> |
-| **HTTPS**          | <a href="https://aws.amazon.com/cloudfront/" target="_blank" rel="noopener">Amazon CloudFront</a> (3 distributions) |
-| **Payments**       | <a href="https://www.payments.service.gov.uk/" target="_blank" rel="noopener">GOV.UK Pay</a> (sandbox)              |
+| Component          | AWS Service                                                               |
+| ------------------ | ------------------------------------------------------------------------- |
+| **Compute**        | [Amazon EC2](https://aws.amazon.com/ec2/) (Windows Server 2022, IIS)      |
+| **Database**       | [Amazon RDS SQL Server Express](https://aws.amazon.com/rds/sqlserver/)    |
+| **Load balancing** | [Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/) |
+| **HTTPS**          | [Amazon CloudFront](https://aws.amazon.com/cloudfront/) (3 distributions) |
+| **Payments**       | [GOV.UK Pay](https://www.payments.service.gov.uk/) (sandbox)              |
 
 </div>
 </div>
@@ -160,7 +160,7 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 ## About LocalGov IMS
 
-<a href="https://github.com/LocalGovIMS/localgov-ims" target="_blank" rel="noopener">LocalGov IMS</a> is an open-source income management system designed for UK local authorities. It provides a complete back-office system for managing council income across multiple fund types.
+[LocalGov IMS](https://github.com/LocalGovIMS/localgov-ims) is an open-source income management system designed for UK local authorities. It provides a complete back-office system for managing council income across multiple fund types.
 
 {{ govukInsetText({
   html: "<strong>Pre-seeded demo data</strong> &bull; 40 account holders &bull; 500 transactions &bull; 19 fund types &bull; 6 users with different roles"
@@ -216,7 +216,7 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 This scenario is built with open source infrastructure as code using AWS CDK (Cloud Development Kit). The IMS application is built from source on a Windows Server EC2 instance with IIS, connecting to RDS SQL Server for data storage.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/localgov-ims" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/localgov-ims)
 
 ---
 
@@ -232,8 +232,8 @@ This scenario is built with open source infrastructure as code using AWS CDK (Cl
 
 ## Learn more about LocalGov IMS
 
-- <a href="https://github.com/LocalGovIMS/localgov-ims" target="_blank" rel="noopener">LocalGov IMS source code on GitHub</a>
-- <a href="https://www.payments.service.gov.uk/" target="_blank" rel="noopener">GOV.UK Pay</a>
+- [LocalGov IMS source code on GitHub](https://github.com/LocalGovIMS/localgov-ims)
+- [GOV.UK Pay](https://www.payments.service.gov.uk/)
 
 ---
 

--- a/src/catalogue/aws/minute.md
+++ b/src/catalogue/aws/minute.md
@@ -39,7 +39,7 @@ github_source: "https://github.com/i-dot-ai/minute"
 ## Overview
 
 {{ govukInsetText({
-  html: "<strong>Built by i.AI, for government</strong><br>Minute is an open-source tool built by <a href='https://ai.gov.uk' target='_blank' rel='noopener'>i.AI</a> (the UK Government's AI team in DSIT) that transforms meeting recordings into structured, professional meeting minutes using AI."
+  html: "<strong>Built by i.AI, for government</strong><br>Minute is an open-source tool built by [i.AI](https://ai.gov.uk) (the UK Government's AI team in DSIT) that transforms meeting recordings into structured, professional meeting minutes using AI."
 }) }}
 
 > **Learning Artifact**: This is a pre-deployed demonstration environment for learning and exploration, not a production-ready product.
@@ -62,28 +62,28 @@ The NDX:Try version replaces the upstream Gemini/Azure dependencies with **AWS-n
 
 ### Core Features
 
-| Feature                                                                                                                                              | AWS Service                                                                                            |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/minute/step-3/" target="_blank" rel="noopener">**Meeting transcription**</a> | <a href="https://aws.amazon.com/transcribe/" target="_blank" rel="noopener">AWS Transcribe</a>         |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/minute/step-5/" target="_blank" rel="noopener">**AI minute generation**</a>  | <a href="https://aws.amazon.com/bedrock/" target="_blank" rel="noopener">Amazon Bedrock</a> (Nova Pro) |
-| **Speaker identification**                                                                                                                           | <a href="https://aws.amazon.com/transcribe/" target="_blank" rel="noopener">AWS Transcribe</a>         |
-| **Multiple meeting templates**                                                                                                                       | Cabinet, Planning Committee, General, and more                                                         |
-| **AI-assisted editing**                                                                                                                              | <a href="https://aws.amazon.com/bedrock/" target="_blank" rel="noopener">Amazon Bedrock</a>            |
-| **Word document export**                                                                                                                             | Built-in                                                                                               |
+| Feature                                                                                                    | AWS Service                                                  |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| [**Meeting transcription**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/minute/step-3/) | [AWS Transcribe](https://aws.amazon.com/transcribe/)         |
+| [**AI minute generation**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/minute/step-5/)  | [Amazon Bedrock](https://aws.amazon.com/bedrock/) (Nova Pro) |
+| **Speaker identification**                                                                                 | [AWS Transcribe](https://aws.amazon.com/transcribe/)         |
+| **Multiple meeting templates**                                                                             | Cabinet, Planning Committee, General, and more               |
+| **AI-assisted editing**                                                                                    | [Amazon Bedrock](https://aws.amazon.com/bedrock/)            |
+| **Word document export**                                                                                   | Built-in                                                     |
 
 </div>
 <div class="govuk-grid-column-one-half">
 
 ### Infrastructure
 
-| Component             | AWS Service                                                                                              |
-| --------------------- | -------------------------------------------------------------------------------------------------------- |
-| **Compute**           | <a href="https://aws.amazon.com/fargate/" target="_blank" rel="noopener">AWS Fargate</a> (3 services)    |
-| **Database**          | <a href="https://aws.amazon.com/rds/aurora/" target="_blank" rel="noopener">Amazon Aurora</a> PostgreSQL |
-| **Message queues**    | <a href="https://aws.amazon.com/sqs/" target="_blank" rel="noopener">Amazon SQS</a> (4 queues)           |
-| **File storage**      | <a href="https://aws.amazon.com/s3/" target="_blank" rel="noopener">Amazon S3</a>                        |
-| **CDN & HTTPS**       | <a href="https://aws.amazon.com/cloudfront/" target="_blank" rel="noopener">Amazon CloudFront</a>        |
-| **Service discovery** | <a href="https://aws.amazon.com/cloud-map/" target="_blank" rel="noopener">AWS Cloud Map</a>             |
+| Component             | AWS Service                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| **Compute**           | [AWS Fargate](https://aws.amazon.com/fargate/) (3 services)    |
+| **Database**          | [Amazon Aurora](https://aws.amazon.com/rds/aurora/) PostgreSQL |
+| **Message queues**    | [Amazon SQS](https://aws.amazon.com/sqs/) (4 queues)           |
+| **File storage**      | [Amazon S3](https://aws.amazon.com/s3/)                        |
+| **CDN & HTTPS**       | [Amazon CloudFront](https://aws.amazon.com/cloudfront/)        |
+| **Service discovery** | [AWS Cloud Map](https://aws.amazon.com/cloud-map/)             |
 
 </div>
 </div>

--- a/src/catalogue/aws/planning-ai.md
+++ b/src/catalogue/aws/planning-ai.md
@@ -56,7 +56,7 @@ This sandbox includes a working implementation using:
 
 Before requesting your sandbox, explore the scenario documentation to understand what's deployed and how to interact with it:
 
-<a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/planning-ai/" target="_blank" rel="noopener">View Planning AI scenario details</a>
+[View Planning AI scenario details](https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/planning-ai/)
 
 ## Getting started
 
@@ -99,7 +99,7 @@ This scenario lets you evaluate whether AI could assist your planning department
 
 This scenario is built with open source infrastructure as code. You can view the CloudFormation template, understand how it works, and adapt it for your own needs.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/planning-ai" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/planning-ai)
 
 ### Build your own
 

--- a/src/catalogue/aws/planx.md
+++ b/src/catalogue/aws/planx.md
@@ -42,7 +42,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 
 > **Learning Artifact**: This is a pre-deployed demonstration environment for learning and exploration, not a production-ready product.
 
-<a href="https://opendigitalplanning.org/plan-x" target="_blank" rel="noopener">PlanX</a> is the open-source digital planning platform developed by <a href="https://www.opensystemslab.io/" target="_blank" rel="noopener">Open Systems Lab</a> as part of the <a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning</a> programme. It's used by 18+ UK councils — including Lambeth, Southwark, Camden, and Buckinghamshire — to create citizen-facing digital planning application services.
+[PlanX](https://opendigitalplanning.org/plan-x) is the open-source digital planning platform developed by [Open Systems Lab](https://www.opensystemslab.io/) as part of the [Open Digital Planning](https://opendigitalplanning.org/) programme. It's used by 18+ UK councils — including Lambeth, Southwark, Camden, and Buckinghamshire — to create citizen-facing digital planning application services.
 
 Service designers build planning application flows in a visual drag-and-drop editor. Citizens then use these flows to submit structured, machine-readable planning applications.
 
@@ -60,25 +60,25 @@ Service designers build planning application flows in a visual drag-and-drop edi
 
 ### Planning Features
 
-| Feature                                                                                                                                          | What it does                                                        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/planx/step-2/" target="_blank" rel="noopener">**Visual flow editor**</a> | Drag-and-drop nodes to build planning application forms             |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/planx/step-3/" target="_blank" rel="noopener">**Node types**</a>         | Questions, checklists, text inputs, file uploads, notices, and more |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/planx/step-4/" target="_blank" rel="noopener">**Live preview**</a>       | See exactly what citizens see as you build                          |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/planx/step-5/" target="_blank" rel="noopener">**GraphQL API**</a>        | Explore planning data through the Hasura console                    |
+| Feature                                                                                                | What it does                                                        |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| [**Visual flow editor**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/planx/step-2/) | Drag-and-drop nodes to build planning application forms             |
+| [**Node types**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/planx/step-3/)         | Questions, checklists, text inputs, file uploads, notices, and more |
+| [**Live preview**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/planx/step-4/)       | See exactly what citizens see as you build                          |
+| [**GraphQL API**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/planx/step-5/)        | Explore planning data through the Hasura console                    |
 
 </div>
 <div class="govuk-grid-column-one-half">
 
 ### Infrastructure
 
-| Component         | AWS Service                                                                                                            |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Compute**       | <a href="https://aws.amazon.com/fargate/" target="_blank" rel="noopener">AWS Fargate (ECS)</a> — 4 services            |
-| **Database**      | <a href="https://aws.amazon.com/rds/aurora/" target="_blank" rel="noopener">Amazon Aurora PostgreSQL</a> Serverless v2 |
-| **GraphQL**       | <a href="https://hasura.io/" target="_blank" rel="noopener">Hasura GraphQL Engine</a> with 374 migrations              |
-| **HTTPS**         | <a href="https://aws.amazon.com/cloudfront/" target="_blank" rel="noopener">Amazon CloudFront</a>                      |
-| **Collaboration** | <a href="https://share.github.io/sharedb/" target="_blank" rel="noopener">ShareDB</a> for real-time editing            |
+| Component         | AWS Service                                                                  |
+| ----------------- | ---------------------------------------------------------------------------- |
+| **Compute**       | [AWS Fargate (ECS)](https://aws.amazon.com/fargate/) — 4 services            |
+| **Database**      | [Amazon Aurora PostgreSQL](https://aws.amazon.com/rds/aurora/) Serverless v2 |
+| **GraphQL**       | [Hasura GraphQL Engine](https://hasura.io/) with 374 migrations              |
+| **HTTPS**         | [Amazon CloudFront](https://aws.amazon.com/cloudfront/)                      |
+| **Collaboration** | [ShareDB](https://share.github.io/sharedb/) for real-time editing            |
 
 </div>
 </div>
@@ -159,10 +159,10 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 ## About PlanX
 
-<a href="https://opendigitalplanning.org/plan-x" target="_blank" rel="noopener">PlanX</a> is developed by **<a href="https://www.opensystemslab.io/" target="_blank" rel="noopener">Open Systems Lab (OSL)</a>** as part of the **<a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning (ODP)</a>** programme.
+[PlanX](https://opendigitalplanning.org/plan-x) is developed by **[Open Systems Lab (OSL)](https://www.opensystemslab.io/)** as part of the **[Open Digital Planning (ODP)](https://opendigitalplanning.org/)** programme.
 
 {{ govukInsetText({
-  html: "<strong>Part of the ODP ecosystem</strong> &bull; <a href='https://opendigitalplanning.org/plan-x' target='_blank' rel='noopener'>PlanX</a> (submissions) &bull; <a href='https://opendigitalplanning.org/back-office-planning-system-bops' target='_blank' rel='noopener'>BOPS</a> (back office) &bull; <a href='https://opendigitalplanning.org/digital-planning-data-and-api' target='_blank' rel='noopener'>Data & API standards</a>"
+  html: "<strong>Part of the ODP ecosystem</strong> &bull; [PlanX](https://opendigitalplanning.org/plan-x) (submissions) &bull; [BOPS](https://opendigitalplanning.org/back-office-planning-system-bops) (back office) &bull; [Data & API standards](https://opendigitalplanning.org/digital-planning-data-and-api)"
 }) }}
 
 <div class="govuk-grid-row">
@@ -219,7 +219,7 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 This scenario is built with open source infrastructure as code using AWS CDK (Cloud Development Kit) with Docker. The PlanX application is the same codebase used in production by UK councils, deployed on ECS Fargate with Aurora PostgreSQL and Hasura GraphQL.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/planx" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/planx)
 
 ---
 
@@ -234,10 +234,10 @@ This scenario is built with open source infrastructure as code using AWS CDK (Cl
 
 ## Learn more about PlanX
 
-- <a href="https://opendigitalplanning.org/plan-x" target="_blank" rel="noopener">PlanX on Open Digital Planning</a>
-- <a href="https://www.opensystemslab.io/" target="_blank" rel="noopener">Open Systems Lab</a>
-- <a href="https://opendigitalplanning.org/" target="_blank" rel="noopener">Open Digital Planning programme</a>
-- <a href="https://github.com/theopensystemslab/planx-new" target="_blank" rel="noopener">PlanX source code on GitHub</a>
+- [PlanX on Open Digital Planning](https://opendigitalplanning.org/plan-x)
+- [Open Systems Lab](https://www.opensystemslab.io/)
+- [Open Digital Planning programme](https://opendigitalplanning.org/)
+- [PlanX source code on GitHub](https://github.com/theopensystemslab/planx-new)
 
 ---
 

--- a/src/catalogue/aws/quicksight-dashboard.md
+++ b/src/catalogue/aws/quicksight-dashboard.md
@@ -51,7 +51,7 @@ This sandbox includes a working implementation using:
 
 Before requesting your sandbox, explore the scenario documentation to understand what's deployed and how to interact with it:
 
-<a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/quicksight-dashboard/" target="_blank" rel="noopener">View QuickSight Dashboard scenario details</a>
+[View QuickSight Dashboard scenario details](https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/quicksight-dashboard/)
 
 ## Getting started
 
@@ -94,7 +94,7 @@ This scenario lets you evaluate whether cloud-based business intelligence could 
 
 This scenario is built with open source infrastructure as code. You can view the CloudFormation template, understand how it works, and adapt it for your own needs.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/quicksight-dashboard" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/quicksight-dashboard)
 
 ### Build your own
 

--- a/src/catalogue/aws/simply-readable.md
+++ b/src/catalogue/aws/simply-readable.md
@@ -59,25 +59,25 @@ Simply Readable brings together **document translation** and **Easy Read convers
 
 ### Core Features
 
-| Feature                                                                                                                                                      | AWS Service                                                                                     |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/simply-readable/step-2/" target="_blank" rel="noopener">**Document translation**</a> | <a href="https://aws.amazon.com/translate/" target="_blank" rel="noopener">Amazon Translate</a> |
-| <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/simply-readable/step-3/" target="_blank" rel="noopener">**Easy Read conversion**</a> | <a href="https://aws.amazon.com/bedrock/" target="_blank" rel="noopener">Amazon Bedrock</a>     |
-| **User authentication**                                                                                                                                      | <a href="https://aws.amazon.com/cognito/" target="_blank" rel="noopener">Amazon Cognito</a>     |
-| **Real-time updates**                                                                                                                                        | <a href="https://aws.amazon.com/appsync/" target="_blank" rel="noopener">AWS AppSync</a>        |
+| Feature                                                                                                            | AWS Service                                           |
+| ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [**Document translation**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/simply-readable/step-2/) | [Amazon Translate](https://aws.amazon.com/translate/) |
+| [**Easy Read conversion**](https://aws.try.ndx.digital.cabinet-office.gov.uk/walkthroughs/simply-readable/step-3/) | [Amazon Bedrock](https://aws.amazon.com/bedrock/)     |
+| **User authentication**                                                                                            | [Amazon Cognito](https://aws.amazon.com/cognito/)     |
+| **Real-time updates**                                                                                              | [AWS AppSync](https://aws.amazon.com/appsync/)        |
 
 </div>
 <div class="govuk-grid-column-one-half">
 
 ### Infrastructure
 
-| Component         | AWS Service                                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------------------ |
-| **Orchestration** | <a href="https://aws.amazon.com/step-functions/" target="_blank" rel="noopener">AWS Step Functions</a> |
-| **Compute**       | <a href="https://aws.amazon.com/lambda/" target="_blank" rel="noopener">AWS Lambda</a>                 |
-| **Storage**       | <a href="https://aws.amazon.com/s3/" target="_blank" rel="noopener">Amazon S3</a>                      |
-| **CDN**           | <a href="https://aws.amazon.com/cloudfront/" target="_blank" rel="noopener">Amazon CloudFront</a>      |
-| **Database**      | <a href="https://aws.amazon.com/dynamodb/" target="_blank" rel="noopener">Amazon DynamoDB</a>          |
+| Component         | AWS Service                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| **Orchestration** | [AWS Step Functions](https://aws.amazon.com/step-functions/) |
+| **Compute**       | [AWS Lambda](https://aws.amazon.com/lambda/)                 |
+| **Storage**       | [Amazon S3](https://aws.amazon.com/s3/)                      |
+| **CDN**           | [Amazon CloudFront](https://aws.amazon.com/cloudfront/)      |
+| **Database**      | [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)          |
 
 </div>
 </div>
@@ -205,7 +205,7 @@ Simply Readable was created by **Swindon Borough Council** to solve a genuine op
 
 ## Governance
 
-Simply Readable is published as an **<a href="https://github.com/aws-samples/document-translation" target="_blank" rel="noopener">AWS Sample</a>** under the MIT-0 licence, making it free for any organisation to use, modify, and deploy. The original innovation came from Swindon Borough Council, demonstrating what's possible when local government leads on digital transformation.
+Simply Readable is published as an **[AWS Sample](https://github.com/aws-samples/document-translation)** under the MIT-0 licence, making it free for any organisation to use, modify, and deploy. The original innovation came from Swindon Borough Council, demonstrating what's possible when local government leads on digital transformation.
 
 The growing adoption by councils across the UK — from Edinburgh to Southampton — shows the power of councils sharing solutions with each other. When one council solves a problem, every council can benefit.
 
@@ -213,9 +213,9 @@ The growing adoption by councils across the UK — from Edinburgh to Southampton
 
 ### How this was built
 
-This scenario is built on the open source <a href="https://github.com/aws-samples/document-translation" target="_blank" rel="noopener">Document Translation</a> project, originally created by Swindon Borough Council and published as an AWS Sample. The NDX:Try deployment adapts it for the Innovation Sandbox environment using AWS CDK.
+This scenario is built on the open source [Document Translation](https://github.com/aws-samples/document-translation) project, originally created by Swindon Borough Council and published as an AWS Sample. The NDX:Try deployment adapts it for the Innovation Sandbox environment using AWS CDK.
 
-<a href="https://github.com/aws-samples/document-translation" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/aws-samples/document-translation)
 
 ---
 
@@ -231,8 +231,8 @@ This scenario is built on the open source <a href="https://github.com/aws-sample
 
 ## Learn More
 
-- <a href="https://github.com/aws-samples/document-translation" target="_blank" rel="noopener">Document Translation on GitHub (AWS Samples)</a>
-- <a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/simply-readable/" target="_blank" rel="noopener">Simply Readable scenario details</a>
+- [Document Translation on GitHub (AWS Samples)](https://github.com/aws-samples/document-translation)
+- [Simply Readable scenario details](https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/simply-readable/)
 
 ## Troubleshooting
 

--- a/src/catalogue/aws/smart-car-park.md
+++ b/src/catalogue/aws/smart-car-park.md
@@ -55,7 +55,7 @@ This sandbox includes a working implementation using:
 
 Before requesting your sandbox, explore the scenario documentation to understand what's deployed and how to interact with it:
 
-<a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/smart-car-park/" target="_blank" rel="noopener">View Smart Car Park scenario details</a>
+[View Smart Car Park scenario details](https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/smart-car-park/)
 
 ## Getting started
 
@@ -98,7 +98,7 @@ This scenario lets you evaluate whether IoT-based parking monitoring could work 
 
 This scenario is built with open source infrastructure as code. You can view the CloudFormation template, understand how it works, and adapt it for your own needs.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/smart-car-park" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/smart-car-park)
 
 ### Build your own
 

--- a/src/catalogue/aws/text-to-speech.md
+++ b/src/catalogue/aws/text-to-speech.md
@@ -52,7 +52,7 @@ This sandbox includes a working implementation using:
 
 Before requesting your sandbox, explore the scenario documentation to understand what's deployed and how to interact with it:
 
-<a href="https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/text-to-speech/" target="_blank" rel="noopener">View Text to Speech scenario details</a>
+[View Text to Speech scenario details](https://aws.try.ndx.digital.cabinet-office.gov.uk/scenarios/text-to-speech/)
 
 ## Getting started
 
@@ -95,7 +95,7 @@ This scenario lets you evaluate whether automated audio generation could improve
 
 This scenario is built with open source infrastructure as code. You can view the CloudFormation template, understand how it works, and adapt it for your own needs.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/text-to-speech" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/text-to-speech)
 
 ### Build your own
 

--- a/src/catalogue/mysociety/fixmystreet.md
+++ b/src/catalogue/mysociety/fixmystreet.md
@@ -48,7 +48,7 @@ github_source: "https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloud
 
 > **Learning Artifact**: This is a pre-deployed demonstration environment for learning and exploration, not a production-ready product.
 
-FixMyStreet is <a href="https://www.mysociety.org/" target="_blank" rel="noopener">mySociety's</a> open-source platform that lets citizens report local problems — potholes, broken streetlights, graffiti, fly-tipping — directly to the council responsible for fixing them. Used by **thousands of UK councils**, it's one of the most successful civic technology platforms in the world.
+FixMyStreet is [mySociety's](https://www.mysociety.org/) open-source platform that lets citizens report local problems — potholes, broken streetlights, graffiti, fly-tipping — directly to the council responsible for fixing them. Used by **thousands of UK councils**, it's one of the most successful civic technology platforms in the world.
 
 This NDX:Try scenario deploys a fully working FixMyStreet instance with **260 seeded demo reports**, **150 citizen updates**, and a **council admin dashboard** — all running on AWS managed infrastructure.
 
@@ -95,13 +95,13 @@ This NDX:Try scenario deploys a fully working FixMyStreet instance with **260 se
 
 ### Infrastructure
 
-| Component          | AWS Service                                                                                                         |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **HTTPS & CDN**    | <a href="https://aws.amazon.com/cloudfront/" target="_blank" rel="noopener">Amazon CloudFront</a>                   |
-| **Load balancing** | <a href="https://aws.amazon.com/elasticloadbalancing/" target="_blank" rel="noopener">Application Load Balancer</a> |
-| **Compute**        | <a href="https://aws.amazon.com/fargate/" target="_blank" rel="noopener">AWS Fargate</a> (3 containers)             |
-| **Database**       | <a href="https://aws.amazon.com/rds/aurora/" target="_blank" rel="noopener">Aurora PostgreSQL</a> with PostGIS      |
-| **File storage**   | <a href="https://aws.amazon.com/efs/" target="_blank" rel="noopener">Amazon EFS</a>                                 |
+| Component          | AWS Service                                                               |
+| ------------------ | ------------------------------------------------------------------------- |
+| **HTTPS & CDN**    | [Amazon CloudFront](https://aws.amazon.com/cloudfront/)                   |
+| **Load balancing** | [Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/) |
+| **Compute**        | [AWS Fargate](https://aws.amazon.com/fargate/) (3 containers)             |
+| **Database**       | [Aurora PostgreSQL](https://aws.amazon.com/rds/aurora/) with PostGIS      |
+| **File storage**   | [Amazon EFS](https://aws.amazon.com/efs/)                                 |
 
 </div>
 <div class="govuk-grid-column-one-half">
@@ -195,7 +195,7 @@ Once you select **"Try this now"** above, your session environment will begin de
 
 ## About FixMyStreet
 
-FixMyStreet was created by <a href="https://www.mysociety.org/" target="_blank" rel="noopener">mySociety</a>, a UK charity that builds digital tools for democracy and civic participation. Launched in 2007, it has become the standard platform for citizen problem reporting across the UK.
+FixMyStreet was created by [mySociety](https://www.mysociety.org/), a UK charity that builds digital tools for democracy and civic participation. Launched in 2007, it has become the standard platform for citizen problem reporting across the UK.
 
 {{ govukInsetText({
   html: "<strong>1 million+ reports</strong> • <strong>Used across the UK</strong> • <strong>Open source since 2007</strong> • <strong>Built by mySociety</strong>"
@@ -244,7 +244,7 @@ FixMyStreet was created by <a href="https://www.mysociety.org/" target="_blank" 
 
 This scenario deploys FixMyStreet using AWS CDK with a custom Docker image extending the official `fixmystreet/fixmystreet:stable` image. The infrastructure includes Aurora PostgreSQL with PostGIS for geospatial data, an nginx sidecar for HTTP routing, and memcached for caching — all orchestrated by AWS Fargate.
 
-<a href="https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/fixmystreet" target="_blank" rel="noopener">View the source code on GitHub <span class="govuk-visually-hidden">(opens in new tab)</span></a>
+[View the source code on GitHub](https://github.com/co-cddo/ndx_try_aws_scenarios/tree/main/cloudformation/scenarios/fixmystreet)
 
 ---
 
@@ -260,7 +260,7 @@ This scenario deploys FixMyStreet using AWS CDK with a custom Docker image exten
 
 ## Learn more
 
-- <a href="https://www.fixmystreet.com/" target="_blank" rel="noopener">FixMyStreet live site</a>
-- <a href="https://fixmystreet.org/" target="_blank" rel="noopener">FixMyStreet Platform documentation</a>
-- <a href="https://github.com/mysociety/fixmystreet" target="_blank" rel="noopener">FixMyStreet source code on GitHub</a>
-- <a href="https://www.mysociety.org/" target="_blank" rel="noopener">mySociety — the charity behind FixMyStreet</a>
+- [FixMyStreet live site](https://www.fixmystreet.com/)
+- [FixMyStreet Platform documentation](https://fixmystreet.org/)
+- [FixMyStreet source code on GitHub](https://github.com/mysociety/fixmystreet)
+- [mySociety — the charity behind FixMyStreet](https://www.mysociety.org/)


### PR DESCRIPTION
## Summary
- Extend the 11ty markdown-it library so any http(s) or protocol-relative link automatically gets `target="_blank"`, `rel="noopener noreferrer"`, and a visually hidden `(opens in new tab)` suffix (skipped if the link text already mentions "tab"/"window"). Internal links are left alone.
- Convert 165 hand-rolled `<a href="…" target="_blank" rel="noopener">…</a>` tags (and their accompanying `govuk-visually-hidden` spans) across 14 catalogue pages back to standard markdown `[text](url)`, so authors no longer need to hand-roll the GOV.UK external-link pattern.

Closes NAP-22.

## Test plan
- [x] `yarn lint` clean
- [x] `yarn build` clean
- [x] `yarn test` — 966/966 pass
- [x] Spot-checked rendered HTML for `_site/catalogue/mysociety/fixmystreet/` — every external link has `target="_blank" rel="noopener noreferrer"` plus the visually hidden suffix; internal nav links unchanged.
- [ ] Manual smoke in browser