### PR TITLE
fix: add explicit "types" to tsconfigs for TS 6.0 compatibility

### DIFF
--- a/infra-signup/tsconfig.json
+++ b/infra-signup/tsconfig.json
@@ -28,7 +28,8 @@
       "@ndx/signup-types": ["../src/signup/types.ts"]
     },
     "baseUrl": ".",
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "types": ["jest", "node", "aws-lambda"]
   },
   "include": ["bin/**/*.ts", "lib/**/*.ts", "../src/signup/types.ts"],
   "exclude": ["node_modules", "dist", "cdk.out", "**/*.d.ts"]

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -19,7 +19,8 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
     "skipLibCheck": true,
-    "typeRoots": ["./node_modules/@types", "./types"]
+    "typeRoots": ["./node_modules/@types", "./types"],
+    "types": ["jest", "node", "aws-lambda"]
   },
   "exclude": ["node_modules", "cdk.out"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "paths": {
       "@try/*": ["try/*"],
       "@signup/*": ["signup/*"]
-    }
+    },
+    "types": ["jest"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "_site", "**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,
@@ -19,7 +19,7 @@
       "@try/*": ["try/*"],
       "@signup/*": ["signup/*"]
     },
-    "types": ["jest"]
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "_site", "**/*.test.ts"]


### PR DESCRIPTION
## Summary
- Adds an explicit `"types"` entry to the three tsconfig.json files (`/`, `/infra`, `/infra-signup`).
- TypeScript 6.0 no longer auto-discovers @types packages from `typeRoots` when no `"types"` field is set, so test files cannot resolve `jest`/`describe`/`expect`/etc. globals.
- Verified locally that tests still pass under TS 5.9 (current main) with the change applied.

## Why
Unblocks dependabot PRs #654, #656, #659 (all of which bump typescript 5.9.3 → 6.0.3 and currently fail with `TS2304: Cannot find name 'jest'`). Once this lands, comment `@dependabot rebase` on each of those PRs to re-run them against the fixed main.

## Test plan
- [x] `cd infra && yarn test` passes locally on TS 5.9
- [x] `cd infra-signup && yarn test lib/lambda/signup/domain-service.test.ts` passes on TS 5.9
- [x] `yarn jest src/try/ui/components/sessions-table.test.ts` passes on TS 5.9
- [x] `cd infra && yarn build` succeeds
- [x] `cd infra-signup && yarn build` succeeds
- [ ] CI green