### PR TITLE
chore(deps-dev): bump typescript from 5.9.3 to 6.0.3 in the npm-root group

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prettier": "^3.8.3",
     "prettier-plugin-sh": "^0.18.1",
     "ts-jest": "^29.4.9",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "npm": "please-use-yarn",

--- a/src/types/styles.d.ts
+++ b/src/types/styles.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css"
+declare module "*.scss"
+declare module "*.sass"
+declare module "*.less"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6037,7 +6037,7 @@ __metadata:
     prettier: "npm:^3.8.3"
     prettier-plugin-sh: "npm:^0.18.1"
     ts-jest: "npm:^29.4.9"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -7447,23 +7447,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=8c6c40"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
+  checksum: 10c0/eed465bd04b344517bd91eb232fd0187d93e34625c65ec93777449e29157c6c2accae409474a68a867b90465224d4908f9bce78ad763c159cacd7263ae24b5fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Re-applies dependabot PR #654 (Dependabot Updates workflow is broken and can't recreate the original PR). Cherry-pick onto current main with the TS 6.0 tsconfig fix from #660.

Supersedes #654.