### PR TITLE
fix(signup): pin domain source to gds-dtx org (renamed from govuk-digital-backbone)

### DIFF
--- a/docs/adr/adr-044-domain-caching.md
+++ b/docs/adr/adr-044-domain-caching.md
@@ -21,4 +21,5 @@ The signup form displays a dropdown of allowed email domains, fetched from a Git
 ## Implementation
 - Cache logic: `infra-signup/lib/lambda/signup/domain-service.ts`
 - TTL constant: `CACHE_TTL_MS = 5 * 60 * 1000`
-- Source URL: `https://raw.githubusercontent.com/govuk-digital-backbone/ukps-domains/main/data/user_domains.json`
+- Source URL: `https://raw.githubusercontent.com/gds-dtx/ukps-domains/main/data/user_domains.json`
+  - Note: the `gds-dtx` org was renamed from `govuk-digital-backbone` on 2026-06-16. GitHub's rename redirect is a temporary alias only — it is released if the old org name is reclaimed, so the URL is pinned to the new name directly rather than relying on the redirect.

--- a/infra-signup/lib/lambda/signup/domain-service.test.ts
+++ b/infra-signup/lib/lambda/signup/domain-service.test.ts
@@ -80,7 +80,7 @@ describe("domain-service", () => {
 
       expect(result).toEqual(sampleDomains)
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://raw.githubusercontent.com/govuk-digital-backbone/ukps-domains/main/data/user_domains.json",
+        "https://raw.githubusercontent.com/gds-dtx/ukps-domains/main/data/user_domains.json",
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       )
     })

--- a/infra-signup/lib/lambda/signup/domain-service.ts
+++ b/infra-signup/lib/lambda/signup/domain-service.ts
@@ -17,8 +17,7 @@ import type { DomainInfo } from "@ndx/signup-types"
  * (org renamed from govuk-digital-backbone on 2026-06-16; GitHub's rename
  * redirect is a temporary alias that breaks if the old name is reclaimed)
  */
-const GITHUB_DOMAIN_URL =
-  "https://raw.githubusercontent.com/gds-dtx/ukps-domains/main/data/user_domains.json"
+const GITHUB_DOMAIN_URL = "https://raw.githubusercontent.com/gds-dtx/ukps-domains/main/data/user_domains.json"
 
 /**
  * Cache TTL in milliseconds (5 minutes per ADR-044, NFR12)

--- a/infra-signup/lib/lambda/signup/domain-service.ts
+++ b/infra-signup/lib/lambda/signup/domain-service.ts
@@ -13,10 +13,12 @@ import type { DomainInfo } from "@ndx/signup-types"
 
 /**
  * GitHub raw URL for the UK public sector domain list.
- * Source: govuk-digital-backbone/ukps-domains repository
+ * Source: gds-dtx/ukps-domains repository
+ * (org renamed from govuk-digital-backbone on 2026-06-16; GitHub's rename
+ * redirect is a temporary alias that breaks if the old name is reclaimed)
  */
 const GITHUB_DOMAIN_URL =
-  "https://raw.githubusercontent.com/govuk-digital-backbone/ukps-domains/main/data/user_domains.json"
+  "https://raw.githubusercontent.com/gds-dtx/ukps-domains/main/data/user_domains.json"
 
 /**
  * Cache TTL in milliseconds (5 minutes per ADR-044, NFR12)
@@ -30,7 +32,7 @@ const CACHE_TTL_MS = 5 * 60 * 1000
 let domainCache: { data: DomainInfo[]; timestamp: number } | null = null
 
 /**
- * Raw domain entry from the govuk-digital-backbone/ukps-domains repository.
+ * Raw domain entry from the gds-dtx/ukps-domains repository.
  */
 interface GitHubDomainEntry {
   domain_pattern: string
@@ -42,7 +44,7 @@ interface GitHubDomainEntry {
 
 /**
  * Expected structure of the GitHub JSON response from the
- * govuk-digital-backbone/ukps-domains repository.
+ * gds-dtx/ukps-domains repository.
  */
 interface GitHubDomainsResponse {
   version: string


### PR DESCRIPTION
## What

Repoints the signup domain allowlist source from the `govuk-digital-backbone` GitHub org to `gds-dtx`, which it was renamed to on 2026-06-16.

- `infra-signup/lib/lambda/signup/domain-service.ts` — `GITHUB_DOMAIN_URL` constant + doc comments
- `infra-signup/lib/lambda/signup/domain-service.test.ts` — expected-URL assertion
- `docs/adr/adr-044-domain-caching.md` — Source URL + note recording the rename

## Why

The org rename only kept working for us because GitHub serves the old owner path via a transparent redirect (verified: old URL returns HTTP 200, byte-identical to the new path). But that redirect is a **temporary alias** — GitHub releases the old org name for anyone to reclaim, with no published grace period, and the redirect dies the moment the name is reused. For a security-relevant domain allowlist, the failure modes are a 404 (signup 503s on cold start with no cache) or, worse, silently fetching a different owner's content. Pinning directly removes that dependency.

No behavioural change. All 28 `domain-service` tests pass locally.

## Deploy

Merge triggers the `signup-cdk-deploy` job (push to `main` + `infra-signup/**` change), which redeploys the Lambda automatically.