### PR TITLE
fix(signup): unblock tsc build under TypeScript 6.0

### DIFF
--- a/infra-signup/tsconfig.json
+++ b/infra-signup/tsconfig.json
@@ -21,6 +21,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
+    "rootDir": "..",
+    "ignoreDeprecations": "6.0",
     "declaration": true,
     "declarationMap": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## What

Adds `rootDir` and `ignoreDeprecations` to `infra-signup/tsconfig.json` so `yarn build` (tsc) passes under TypeScript 6.0.

## Why

The signup deploy job runs `yarn build` as a pre-deploy validation gate. Since the TypeScript 6.0.3 bump (#663) this has failed, so **the signup Lambda has not deployed** (the previous signup deploy on commit `7c4c5c3` failed identically, and #687's deploy just failed the same way):

- `TS5011`: `rootDir` must be set explicitly — the tsconfig includes shared types from `../src/signup/*`, so the common source dir is `..`
- `TS5101`: `baseUrl` is deprecated in TS 7.0

The PR test/lint checks stay green because they run `yarn test` (ts-jest) and `eslint`, not `tsc`. Only the deploy job runs the full compile.

## Safety

The Lambda is bundled by `NodejsFunction`/esbuild directly from source (`lambda/signup/handler.ts`); nothing consumes the tsc `dist` output, so the `rootDir` layout change has no artifact impact.

Verified locally: `yarn build`, `npx cdk synth --quiet` (the deploy gate), and all 194 tests pass.

## Effect

Unblocks `signup-cdk-deploy`, which then deploys the merged `gds-dtx` domain-source change (#687).