### PR TITLE
fix(ci): source ISB role GroupId from cdk.json, not an unset secret

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -416,12 +416,19 @@ jobs:
           role-to-assume: arn:aws:iam::955063685555:role/GitHubActions-ISB-InfraDeploy
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Validate required secrets
+      # The NDX Users group ID is not a secret: it is already committed in
+      # infra-signup/cdk.json (the `groupId` context the signup Lambda deploys
+      # with). Source it from there so the cross-account role scope stays in
+      # lockstep with the Lambda's GROUP_ID, with a single source of truth.
+      - name: Resolve GroupId from CDK context
+        id: groupid
         run: |
-          if [ -z "${{ secrets.ISB_NDX_USERS_GROUP_ID }}" ]; then
-            echo "::error::ISB_NDX_USERS_GROUP_ID secret is not set"
+          GROUP_ID=$(jq -r '.context.groupId // empty' infra-signup/cdk.json)
+          if [ -z "$GROUP_ID" ]; then
+            echo "::error::groupId not found in infra-signup/cdk.json context"
             exit 1
           fi
+          echo "group-id=$GROUP_ID" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Cross-Account Role
         run: |
@@ -430,7 +437,7 @@ jobs:
             --stack-name ndx-signup-cross-account-role \
             --capabilities CAPABILITY_NAMED_IAM \
             --parameter-overrides \
-              GroupId=${{ secrets.ISB_NDX_USERS_GROUP_ID }} \
+              GroupId=${{ steps.groupid.outputs.group-id }} \
             --tags \
               project=ndx \
               feature=signup \


### PR DESCRIPTION
## What

The `ISB Cross-Account Role Deploy` job now reads the NDX Users group ID from `infra-signup/cdk.json` (via `jq`) instead of the `ISB_NDX_USERS_GROUP_ID` GitHub secret.

## Why

That secret has **never been set**, so the job has failed its guard (`exit 1`) on every signup infra run — it's the sole remaining red on `main`'s Infrastructure workflow (the `Signup CDK Deploy` job is green).

The value isn't actually a secret: `a8412370-…` is already committed in `infra-signup/cdk.json` as the `groupId` context the signup Lambda deploys with, and it matches the live Lambda's `GROUP_ID` env. Sourcing the role's `CreateGroupMembership` scope from the same place keeps the two in lockstep from a single source of truth, and removes a manually-managed secret that can silently drift.

## Verification

- `jq -r '.context.groupId' infra-signup/cdk.json` → `a8412370-2051-702a-84d1-6688eeee30fa`, exact match to the deployed Lambda's `GROUP_ID`.
- No untrusted input: the value comes from a committed repo file, not event payloads.

## Effect

Unblocks the `ISB Cross-Account Role Deploy` job, turning `main`'s Infrastructure workflow fully green on next push.